### PR TITLE
corrected method-signature for php7-compatibility

### DIFF
--- a/action/editcommit.php
+++ b/action/editcommit.php
@@ -24,7 +24,7 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
         io_mkdir_p($this->temp_dir);
     }
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
 
         $controller->register_hook('IO_WIKIPAGE_WRITE', 'AFTER', $this, 'handle_io_wikipage_write');
         $controller->register_hook('MEDIA_UPLOAD_FINISH', 'AFTER', $this, 'handle_media_upload');


### PR DESCRIPTION
Should fix
```
Declaration of action_plugin_gitbacked_editcommit::register(Doku_Event_Handler &$controller) should be compatible with DokuWiki_Action_Plugin::register(Doku_Event_Handler $controller) in /home/devteam/app/dokuwiki-2015-08-10a/lib/plugins/gitbacked/action/editcommit.php on line 0,
```

Works for me, but I am no PHP-developer so better have a look...