### PR TITLE
Update remote when only using periodic pull

### DIFF
--- a/action/editcommit.php
+++ b/action/editcommit.php
@@ -29,7 +29,7 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
         $controller->register_hook('IO_WIKIPAGE_WRITE', 'AFTER', $this, 'handle_io_wikipage_write');
         $controller->register_hook('MEDIA_UPLOAD_FINISH', 'AFTER', $this, 'handle_media_upload');
         $controller->register_hook('MEDIA_DELETE_FILE', 'AFTER', $this, 'handle_media_deletion');
-        $controller->register_hook('DOKUWIKI_DONE', 'AFTER', $this, 'handle_periodic_pull');
+        $controller->register_hook('DOKUWIKI_DONE', 'AFTER', $this, 'handle_periodic_pull_with_push');
     }
 
     private function initRepo() {
@@ -100,7 +100,7 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
         return $GLOBALS['USERINFO']['mail'];
     }
 
-    public function handle_periodic_pull(Doku_Event &$event, $param) {
+    public function handle_periodic_pull_with_push(Doku_Event &$event, $param) {
         if ($this->getConf('periodicPull')) {
             $lastPullFile = $this->temp_dir.'/lastpull.txt';
             //check if the lastPullFile exists
@@ -119,8 +119,8 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
 
                 //execute the pull request
                 $repo->pull('origin',$repo->active_branch());
-		//after pulling in changes, push local changes to the remote    
-		$repo->push('origin',$repo->active_branch());
+                //after pulling in changes, push local changes to the remote
+                $repo->push('origin',$repo->active_branch());
 
                 //save the current time to the file to track the last pull execution
                 file_put_contents($lastPullFile,serialize(time()));

--- a/action/editcommit.php
+++ b/action/editcommit.php
@@ -119,6 +119,8 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
 
                 //execute the pull request
                 $repo->pull('origin',$repo->active_branch());
+		//after pulling in changes, push local changes to the remote    
+		$repo->push('origin',$repo->active_branch());
 
                 //save the current time to the file to track the last pull execution
                 file_put_contents($lastPullFile,serialize(time()));

--- a/lib/Git.php
+++ b/lib/Git.php
@@ -637,7 +637,7 @@ class GitRepo {
 	 * @return string
 	 */
 	public function pull($remote, $branch) {
-		return $this->run("pull $remote $branch");
+		return $this->run("pull --rebase $remote $branch");
 	}
 
 	/**


### PR DESCRIPTION
At this point in time the only (builtin) way of pushing local changes is when "push after commit" is active. But this can lead to errors when there are remote changes (since you always have to pull before you can push).

This change adds a pull to the periodic task to push changes. 

Alternatively the "push after commit" could be extended to always pull in changes before pushing.