### PR TITLE
Dokuwki, push to upstream, if upstream in connetable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ If you install this plugin manually, make sure that:
 Please refer to http://www.dokuwiki.org/plugins for additional info
 on how to install plugins in DokuWiki.
 
+## Packages required:
+- git
+- openssh-client (for repos accessed via ssh)
+- iputils-ping (for the pingPushHost parameter)
+
 ## Maintainers
 
 - [@mhoffrog (Markus Hoffrogge)](https://github.com/mhoffrog)

--- a/action/editcommit.php
+++ b/action/editcommit.php
@@ -83,11 +83,20 @@ class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
 				//add the changed file and set the commit message
 				$repo->add($filePath);
 				$repo->commit($message);
-
+				
+					if (!empty($this->getConf('pushAfterCommit'))) {
+						// ping first
+						$retval = -1;
+						system("ping  -c 1 -W 0.1 $this->getConf('pushAfterCommit')", $retval);
+						if ($retval != 0) { 
+							return;
+					}
+				}
 				//if the push after Commit option is set we push the active branch to origin
 				if ($this->getConf('pushAfterCommit')) {
 					$repo->push('origin',$repo->active_branch());
 				}
+				
 			} catch (Exception $e) {
 				if (!$this->isNotifyByEmailOnGitCommandError()) {
 					throw new Exception('Git committing or pushing failed: '.$e->getMessage(), 1, $e);

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,6 +5,7 @@
  * @author Wolfgang Gassler <wolfgang@gassler.org>
  */
 
+$conf['pingPushHost'] = '';
 $conf['pushAfterCommit'] = 0;
 $conf['periodicPull'] = 0;
 $conf['periodicMinutes'] = 60;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,6 +5,7 @@
  * @author Wolfgang Gassler <wolfgang@gassler.org>
  */
 
+$meta['pingPushHost'] = array('string');
 $meta['pushAfterCommit'] = array('onoff');
 $meta['periodicPull'] = array('onoff');
 $meta['periodicMinutes'] = array('numeric');

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -5,7 +5,7 @@
  *
  * @author Markus Hoffrogge <mhoffrogge@gmail.com>
  */
-
+$lang['pingPushHost'] = 'Ping the push host, to make sure it is available before pushing. empty to disable';
 $lang['pushAfterCommit'] = 'Push des aktiven Branch zum remote origin nach jedem commit';
 $lang['periodicPull'] = 'Pull des remote git Repositories alle "periodicMinutes", getriggert von einem http Page Request';
 $lang['periodicMinutes'] = 'Zeitraum (in Minuten) zwischen den periodischen pull requests';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,6 +6,7 @@
  * @author Wolfgang Gassler <wolfgang@gassler.org>
  */
 
+$lang['pingPushHost'] = 'Ping the push host, to make sure it is available before pushing. empty to disable';
 $lang['pushAfterCommit'] = 'Push active branch to remote origin after every commit';
 $lang['periodicPull'] = 'Pull the remote git repository every "periodicMinutes" triggered by a http page request';
 $lang['periodicMinutes'] = 'Timespan (in minutes) between periodic pull requests';


### PR DESCRIPTION
This is useful for people running wiki's offline, which need to then sync back up at a later time.

My use case is:

1. I have a copy of dokuwiki in a docker container on my laptop.
2. I make commits to it, when offline / and or not connected to the network with the git repo.
3. I push/pull later when online.. or when I next do a an edit and am online.

The code makes sure that the plugin does not cause dokuwiki to hang.

Squash commits on merge.