### PR TITLE
Fix to support Cyrillic commit messages

### DIFF
--- a/action/editcommit.php
+++ b/action/editcommit.php
@@ -20,9 +20,7 @@ require_once dirname(__FILE__).'/../lib/GitBackedUtil.php';
 class action_plugin_gitbacked_editcommit extends DokuWiki_Action_Plugin {
 
     function __construct() {
-        global $conf;
-        $this->temp_dir = $conf['tmpdir'].'/gitbacked';
-        io_mkdir_p($this->temp_dir);
+        $this->temp_dir = GitBackedUtil::getTempDir();
     }
 
     public function register(Doku_Event_Handler $controller) {

--- a/lib/Git.php
+++ b/lib/Git.php
@@ -484,7 +484,12 @@ class GitRepo {
 	 */
 	public function commit($message = "", $commit_all = true) {
 		$flags = $commit_all ? '-av' : '-v';
-		return $this->run("commit --allow-empty ".$flags." -m ".escapeshellarg($message));
+		$msgfile = GitBackedUtil::createMessageFile($message);
+		try {
+		  return $this->run("commit --allow-empty ".$flags." --file=".$msgfile);
+		} finally {
+		  unlink($msgfile);
+		}
 	}
 
 	/**
@@ -679,7 +684,12 @@ class GitRepo {
 		if ($message === null) {
 			$message = $tag;
 		}
-		return $this->run("tag -a $tag -m " . escapeshellarg($message));
+		$msgfile = GitBackedUtil::createMessageFile($message);
+		try {
+		  return $this->run("tag -a $tag --file=".$msgfile);
+		} finally {
+		  unlink($msgfile);
+		}
 	}
 
 	/**

--- a/lib/GitBackedUtil.php
+++ b/lib/GitBackedUtil.php
@@ -26,6 +26,13 @@ if (__FILE__ == $_SERVER['SCRIPT_FILENAME']) die('Bad load order');
 class GitBackedUtil {
 
     /**
+     * GitBacked temp directory
+     *
+     * @var string
+     */
+    protected static $temp_dir = '';
+
+    /**
      * Checks, if a given path name is an absolute path or not.
      * This function behaves like absolute path determination in dokuwiki init.php fullpath() method.
      * The relevant code has been copied from there.
@@ -74,6 +81,40 @@ class GitBackedUtil {
             $ret = DOKU_INC.$ret;
         }
         return $ret;
+    }
+
+    /**
+     * Returns the temp dir for GitBacked plugin.
+     * It ensures that the temp dir will be created , if not yet existing.
+     *
+     * @access  public
+     * @return  string          the gitbacked temp directory name
+     */
+    public static function getTempDir() {
+        if (empty(self::$temp_dir)) {
+            global $conf;
+            self::$temp_dir = $conf['tmpdir'].'/gitbacked';
+            io_mkdir_p(self::$temp_dir);
+        }
+        return self::$temp_dir;
+    }
+
+    /**
+     * Creates a temp file and writes the $message to it.
+     * It ensures that the temp dir will be created , if not yet existing.
+     *
+     * @access  public
+     * @param   string $message the text message
+     * @return  string          the temp filename created
+     */
+    public static function createMessageFile($message) {
+        $tmpfname = tempnam(self::getTempDir(), 'gitMessage_');
+        $handle = fopen($tmpfname, "w");
+        if (!empty($message)) {
+            fwrite($handle, $message);
+        }
+        fclose($handle);
+        return $tmpfname;
     }
 
 }


### PR DESCRIPTION
As described by #82 this PR fixes the cutting of cyrillic commit messages.
This fix has been tested on a PHP 7.4 DokuWiki (Hogfather) instance on a Linux and Windows OS.

fixes #82