### PR TITLE
Avoid Using $_ENV

### DIFF
--- a/lib/Git.php
+++ b/lib/Git.php
@@ -302,27 +302,9 @@ class GitRepo {
 			2 => array('pipe', 'w'),
 		);
 		$pipes = array();
-		/* Depending on the value of variables_order, $_ENV may be empty.
-		 * In that case, we have to explicitly set the new variables with
-		 * putenv, and call proc_open with env=null to inherit the reset
-		 * of the system.
-		 *
-		 * This is kind of crappy because we cannot easily restore just those
-		 * variables afterwards.
-		 *
-		 * If $_ENV is not empty, then we can just copy it and be done with it.
-		 */
-		if(count($_ENV) === 0) {
-			$env = NULL;
-			foreach($this->envopts as $k => $v) {
-				putenv(sprintf("%s=%s",$k,$v));
-			}
-		} else {
-			$env = array_merge($_ENV, $this->envopts);
-		}
 		$cwd = $this->repo_path;
 		//dbglog("GitBacked - cwd: [".$cwd."]");
-		$resource = proc_open($command, $descriptorspec, $pipes, $cwd, $env);
+		$resource = proc_open($command, $descriptorspec, $pipes, $cwd, $this->envopts);
 
 		$stdout = stream_get_contents($pipes[1]);
 		$stderr = stream_get_contents($pipes[2]);


### PR DESCRIPTION
PHP exposes sensitive information like cookies in $_ENV. Additionally, it may include command line arguments (argv) as an array in $_ENV in certain configurations, causing a warning because proc_open expects env to be an array of string and would issue a warning when it happens:

Warning: Array to string conversion

Because the existing environment information are not generally useful for Git operations anyways, simply remove the merging of existing $_ENV. Instead, the environment options passed from caller are directly passed to proc_open as is, ensuring more controlled and secure handling of environment variables.