### PR TITLE
update index on pull

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,6 +8,7 @@
 $conf['pushAfterCommit'] = 0;
 $conf['periodicPull'] = 0;
 $conf['periodicMinutes'] = 60;
+$conf['updateIndexOnPull'] = 0;
 $conf['commitPageMsg']	= 'Wiki page %page% changed with summary [%summary%] by %user%';
 $conf['commitPageMsgDel']	= 'Wiki page %page% deleted with reason [%summary%] by %user%';
 $conf['commitMediaMsg']	= 'Wiki media %media% uploaded by %user%';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,6 +7,7 @@
 
 $meta['pushAfterCommit'] = array('onoff');
 $meta['periodicPull'] = array('onoff');
+$meta['updateIndexOnPull'] = array('onoff');
 $meta['periodicMinutes'] = array('numeric');
 $meta['commitPageMsg'] = array('string');
 $meta['commitPageMsgDel'] = array('string');


### PR DESCRIPTION
hello, this change allow for updating the search index on pull so that new or changed pages are searcheable straigth away. We need it for our use cases that's search heavy and need to by up to date.

It works by getting the list of files changed between the two revisions, filter those who are pages and calling the index updater on them.

Probably needs a bit of testing, it works on windows in my setup tho.

Eventually it could be made to fail silently or with a small warning.